### PR TITLE
Update the docker image of clj-kondo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10
 
-FROM borkdude/clj-kondo AS clj-kondo
+FROM cljkondo/clj-kondo AS clj-kondo
 
 FROM clojure AS lein
 FROM clojure:tools-deps-alpine


### PR DESCRIPTION
`clj-kondo` has been moved to https://hub.docker.com/r/cljkondo/clj-kondo

cf. https://github.com/chrovis/cljam/pull/234/checks?check_run_id=2691277774#step:2:14