### PR TITLE
Run from the pre-build Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ COPY LICENSE README.md /
 COPY entrypoint.sh /entrypoint.sh
 COPY lib /lint-action-clj
 
+RUN cd /lint-action-clj && clojure -Stree -P && rm -r .cpcache
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
       default: '[:bad-arglists :constant-test :def-in-def :deprecations :keyword-typos :local-shadows-var :misplaced-docstrings :no-ns-form-found :redefd-vars :suspicious-expression :suspicious-test :unlimited-use :unused-fn-args :unused-locals :unused-meta-on-macro :unused-namespaces :unused-private-vars :unused-ret-vals :unused-ret-vals-in-try :wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag]'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://xcoo/clj-lint-action:latest'
   args:
     - ${{ inputs.linters }}
     - ${{ inputs.sourceroot }}

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -1,5 +1,10 @@
-{:deps {cheshire {:mvn/version "5.10.0"}
-        clj-http {:mvn/version "3.10.0"}
-        environ {:mvn/version "1.1.0"}
+{:deps {cheshire {:mvn/version "5.10.1"}
+        clj-http {:mvn/version "3.12.3"}
+        environ {:mvn/version "1.2.0"}
         clj-time {:mvn/version "0.15.2"}
-        org.clojure/clojure {:mvn/version "1.10.1"}}}
+        org.clojure/clojure {:mvn/version "1.10.3"}
+        ;; linters
+        cljfmt {:mvn/version "RELEASE"}
+        clj-kondo/clj-kondo {:mvn/version "RELEASE"}
+        jonase/eastwood {:mvn/version "RELEASE"}
+        tvaughan/kibit-runner {:mvn/version "RELEASE"}}}


### PR DESCRIPTION
Instead of running a build from `Dockerfile` by each trigger, I simplified the steps and reduced the time required for CI execution using the pre-built Docker image. And I also changed to cache the linters' JARs in the image.