### PR TITLE
Add support for eastwood-arguments.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,17 @@
-FROM alpine:3.10
-
-FROM cljkondo/clj-kondo AS clj-kondo
-
-FROM clojure AS lein
+FROM cljkondo/clj-kondo:2022.05.31-alpine AS clj-kondo
 FROM clojure:tools-deps-alpine
 
-COPY --from=clj-kondo /usr/local/bin/clj-kondo /usr/local/bin/clj-kondo
+COPY --from=clj-kondo /bin/clj-kondo /usr/local/bin/clj-kondo
 
 RUN apk add git
-
 
 ADD https://raw.github.com/technomancy/leiningen/stable/bin/lein /usr/local/bin/lein
 RUN chmod 744 /usr/local/bin/lein
 
-
-COPY LICENSE README.md /
-
 COPY entrypoint.sh /entrypoint.sh
 COPY lib /lint-action-clj
 
-RUN cd /lint-action-clj && clojure -Stree -P && rm -r .cpcache
+WORKDIR /lint-action-clj
+RUN clojure -Stree -P && rm -r .cpcache
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM cljkondo/clj-kondo:2022.05.31-alpine AS clj-kondo
 FROM clojure:tools-deps-alpine
-
-COPY --from=clj-kondo /bin/clj-kondo /usr/local/bin/clj-kondo
+COPY --from=cljkondo/clj-kondo:2022.05.31-alpine /bin/clj-kondo /usr/local/bin/clj-kondo
 
 RUN apk add git
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Run some linters such as clj-kondo , kibit , eastwood and show results as warnin
         runner: ":leiningen"
         base_sha: ${{ github.event.pull_request.base.sha||github.event.before }}
         eastwood_linters: "[:all]"
+        eastwood_args: "{}"
 ```
 
 ## about 'linters'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Run some linters such as clj-kondo , kibit , eastwood and show results as warnin
         runner: ":leiningen"
         base_sha: ${{ github.event.pull_request.base.sha||github.event.before }}
         eastwood_linters: "[:all]"
-        eastwood_args: "{}"
+        linter_options: "{}"
 ```
 
 ## about 'linters'
@@ -23,4 +23,11 @@ if you want to select linters,set variable 'linters' like this.
 
 ```yaml
         linters: "[\"clj-kondo\" \"kibit\" \"eastwood\" \"cljfmt\"]"
+```
+
+## about `linter_options`
+`linter_options` is the options for clj-kondo and eastwood.
+```
+linter_options: "{:clj-kondo {:linters {:redundant-let {:level :info}}}\
+                  :eastwood {:exclude-namespaces [tmp-clj.core2]}}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
   eastwood_linters:
       description: 'Eastwood linters'
       default: '[:bad-arglists :constant-test :def-in-def :deprecations :keyword-typos :local-shadows-var :misplaced-docstrings :no-ns-form-found :redefd-vars :suspicious-expression :suspicious-test :unlimited-use :unused-fn-args :unused-locals :unused-meta-on-macro :unused-namespaces :unused-private-vars :unused-ret-vals :unused-ret-vals-in-try :wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag]'
-  eastwood_args:
-      description: 'Eastwood args'
+  linter_options:
+      description: 'Linter options'
       default: '{}'
 runs:
   using: 'docker'
@@ -32,4 +32,4 @@ runs:
     - ${{ inputs.runner }}
     - ${{ inputs.base_sha }}
     - ${{ inputs.eastwood_linters }}
-    - ${{ inputs.eastwood_args }}
+    - ${{ inputs.linter_options }}

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   eastwood_linters:
       description: 'Eastwood linters'
       default: '[:bad-arglists :constant-test :def-in-def :deprecations :keyword-typos :local-shadows-var :misplaced-docstrings :no-ns-form-found :redefd-vars :suspicious-expression :suspicious-test :unlimited-use :unused-fn-args :unused-locals :unused-meta-on-macro :unused-namespaces :unused-private-vars :unused-ret-vals :unused-ret-vals-in-try :wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag]'
+  eastwood_args:
+      description: 'Eastwood args'
+      default: '{}'
 runs:
   using: 'docker'
   image: 'docker://xcoo/clj-lint-action:latest'
@@ -29,3 +32,4 @@ runs:
     - ${{ inputs.runner }}
     - ${{ inputs.base_sha }}
     - ${{ inputs.eastwood_linters }}
+    - ${{ inputs.eastwood_args }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,4 +22,4 @@ echo "FILES=" $FILES
 
 cd /lint-action-clj
 
-clojure -m lint-action "{:linters $1 :cwd \"${GITHUB_WORKSPACE}\" :mode :github-action :relative-dir $2  :file-target :git :runner $3 :git-sha \"${GITHUB_SHA}\" :use-files true :files [$FILES] :eastwood-linters $5 :eastwood-args $6}"
+clojure -m lint-action "{:linters $1 :cwd \"${GITHUB_WORKSPACE}\" :mode :github-action :relative-dir $2  :file-target :git :runner $3 :git-sha \"${GITHUB_SHA}\" :use-files true :files [$FILES] :eastwood-linters $5 :linter-options $6}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,4 +22,4 @@ echo "FILES=" $FILES
 
 cd /lint-action-clj
 
-clojure -m lint-action "{:linters $1 :cwd \"${GITHUB_WORKSPACE}\" :mode :github-action :relative-dir $2  :file-target :git :runner $3 :git-sha \"${GITHUB_SHA}\" :use-files true :files [$FILES] :eastwood-linters $5}"
+clojure -m lint-action "{:linters $1 :cwd \"${GITHUB_WORKSPACE}\" :mode :github-action :relative-dir $2  :file-target :git :runner $3 :git-sha \"${GITHUB_SHA}\" :use-files true :files [$FILES] :eastwood-linters $5 :eastwood-args $6}"


### PR DESCRIPTION
I add support for interface for passing options to Eastwood.
The changes are given an additional map and merged into the arguments given to eastwood.

The current `actoin.yml` pulls the image, so I checked it in the following environment.
```
$ tree .github
.github
├── actions
│   └── clj-lint-action
│       ├── Dockerfile
│       ├── LICENSE
│       ├── README.md
│       ├── action.yml
│       ├── entrypoint.sh
│       └── lib
│           ├── deps.edn
│           └── src
│               └── lint_action.clj
└── workflows
    └── lint.yml

$ cat .github/workflows/lint.yml|grep clj-lint-action
    - uses: ./.github/actions/clj-lint-action
  
$ cat .github/actions/clj-lint-action/action.yml|grep image
  image: Dockerfile
```
