### PR TITLE
Add support for arm.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,8 @@ RUN script/compile && \
 
 FROM clojure:tools-deps-jammy
 COPY --from=build-clj-kondo /clj-kondo /usr/local/bin/clj-kondo
-
-ADD https://raw.github.com/technomancy/leiningen/stable/bin/lein /usr/local/bin/lein
-RUN chmod 744 /usr/local/bin/lein
+COPY --from=build-clj-kondo /usr/local/bin/lein /usr/local/bin/lein
+RUN chmod +x /usr/local/bin/lein
 
 COPY entrypoint.sh /entrypoint.sh
 COPY lib /lint-action-clj

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run some linters such as clj-kondo , kibit , eastwood and show results as warnin
 ```yaml
     steps:
     - uses: actions/checkout@v2
-    - uses: xcoo/clj-lint-action@v1.1.10
+    - uses: xcoo/clj-lint-action@v1.1.11
       with:
         linters: "\"all\""
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -l
 
 BRANCH_NAME=${GITHUB_REF#refs/heads/}
+git config --global --add safe.directory /github/workspace
 
 if [ -n "$4" ] && [ "$4" != "0000000000000000000000000000000000000000" ]
 then


### PR DESCRIPTION
This PR adds support for running this software in Docker on ARM.
- Added the build of clj-kondo to the Dockerfile because  there is no Docker image for clj-kondo for ARM.
- Fixed entrypoint.sh to avoid permission issues with git commands on Ubuntu-based images.
- Redundant code that unzips by combining `gunzip` and `tar` and code that re-adds PATH is to avoid build failure on ARM.

Version (>20.10.16) Docker Confirmed to work with images built with docker.
- https://github.com/xcoo/clj-lint-action/issues/5#issuecomment-1234070775