### PR TITLE
Update clj-kondo v2023.04.14 and Add deploy workflow.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: deploy
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: xcoo/clj-lint-action
+          tags: type=semver,pattern={{version}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/graalvm/native-image:22.2.0 AS build-clj-kondo
 
 RUN microdnf install -y gzip tar && \
-    curl -LO  https://github.com/clj-kondo/clj-kondo/archive/refs/tags/v2022.08.03.tar.gz && \
-    gunzip v2022.08.03.tar.gz && \
-    tar -xvf v2022.08.03.tar
+    curl -LO  https://github.com/clj-kondo/clj-kondo/archive/refs/tags/v2023.04.14.tar.gz && \
+    gunzip v2023.04.14.tar.gz && \
+    tar -xvf v2023.04.14.tar
 
-WORKDIR /app/clj-kondo-2022.08.03/
+WORKDIR /app/clj-kondo-2023.04.14/
 ENV GRAALVM_HOME /usr
 
 RUN curl -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
       default: '{}'
 runs:
   using: 'docker'
-  image: 'docker://xcoo/clj-lint-action:latest'
+  image: 'docker://xcoo/clj-lint-action:0.1.12'
   args:
     - ${{ inputs.linters }}
     - ${{ inputs.sourceroot }}


### PR DESCRIPTION
This pr add workflows that push to dockerhub and update clj-kondo version in the Docker image.
- memo:Clj-kondo 2023.03.17 and later versions can ignore certain lints.
