### PR TITLE
Update the org name of cljfmt

### DIFF
--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -4,7 +4,7 @@
         clj-time {:mvn/version "0.15.2"}
         org.clojure/clojure {:mvn/version "1.10.3"}
         ;; linters
-        cljfmt {:mvn/version "RELEASE"}
+        dev.weavejester/cljfmt {:mvn/version "RELEASE"}
         clj-kondo/clj-kondo {:mvn/version "RELEASE"}
         jonase/eastwood {:mvn/version "RELEASE"}
         tvaughan/kibit-runner {:mvn/version "RELEASE"}}}


### PR DESCRIPTION
cljfmt `0.16.4` is available but the latest release of `cljfmt` (or `cljfmt/cljfmt`) is [`0.9.4`](https://clojars.org/cljfmt).
It seems like cljfmt is deployed to cljars as [`dev.weavejester/cljfmt`](https://clojars.org/dev.weavejester/cljfmt/versions) since `0.10.1`.