### PR TITLE
Use managed deps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,29 +11,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: xcoo/clj-lint-action
           tags: type=semver,pattern={{version}}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image:22.2.0 AS build-clj-kondo
+FROM ghcr.io/graalvm/native-image:22.3.3 AS build-clj-kondo
 
 ARG CLJ_KONDO_VERSION=2025.02.20
 RUN microdnf install -y gzip tar && \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run some linters such as clj-kondo , kibit , eastwood and show results as warnin
 ```yaml
     steps:
     - uses: actions/checkout@v6
-    - uses: xcoo/clj-lint-action@v1.1.11
+    - uses: xcoo/clj-lint-action@v1.1.15
       with:
         linters: "\"all\""
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Run some linters such as clj-kondo , kibit , eastwood and show results as warnin
 
 ```yaml
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - uses: xcoo/clj-lint-action@v1.1.11
       with:
         linters: "\"all\""

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
       default: '{}'
 runs:
   using: 'docker'
-  image: 'docker://xcoo/clj-lint-action:0.1.12'
+  image: 'docker://xcoo/clj-lint-action:1.1.15'
   args:
     - ${{ inputs.linters }}
     - ${{ inputs.sourceroot }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,4 +23,4 @@ echo "FILES=" $FILES
 
 cd /lint-action-clj
 
-clojure -m lint-action "{:linters $1 :cwd \"${GITHUB_WORKSPACE}\" :mode :github-action :relative-dir $2  :file-target :git :runner $3 :git-sha \"${GITHUB_SHA}\" :use-files true :files [$FILES] :eastwood-linters $5 :linter-options $6}"
+clojure -M -m lint-action "{:linters $1 :cwd \"${GITHUB_WORKSPACE}\" :mode :github-action :relative-dir $2  :file-target :git :runner $3 :git-sha \"${GITHUB_SHA}\" :use-files true :files [$FILES] :eastwood-linters $5 :linter-options $6}"

--- a/lib/deps.edn
+++ b/lib/deps.edn
@@ -1,7 +1,7 @@
-{:deps {cheshire {:mvn/version "5.10.1"}
-        clj-http {:mvn/version "3.12.3"}
-        environ {:mvn/version "1.2.0"}
-        clj-time {:mvn/version "0.15.2"}
+{:deps {cheshire/cheshire {:mvn/version "5.10.1"}
+        clj-http/clj-http {:mvn/version "3.12.3"}
+        environ/environ {:mvn/version "1.2.0"}
+        clj-time/clj-time {:mvn/version "0.15.2"}
         org.clojure/clojure {:mvn/version "1.10.3"}
         ;; linters
         dev.weavejester/cljfmt {:mvn/version "RELEASE"}

--- a/lib/src/lint_action.clj
+++ b/lib/src/lint_action.clj
@@ -81,10 +81,7 @@
                     (str "[clj-kondo]" (nth matches 5))}))))))
 
 (defn- run-cljfmt [files cwd relative-dir]
-  (let [cljfmt-result (sh "clojure"
-                          "-Sdeps" (str {:deps {'cljfmt {:mvn/version "RELEASE"}}})
-                          "-m"
-                          "cljfmt.main" "check"
+  (let [cljfmt-result (sh "clojure" "-M" "-m" "cljfmt.main" "check"
                           (cstr/join " " files))]
     (when-not (zero? (:exit cljfmt-result))
       (->> (:err cljfmt-result)
@@ -100,11 +97,7 @@
                      :message (str "[cljfmt] cljfmt fail." file)})))))))
 
 (defn- run-eastwood-clj [dir namespaces linters options]
-  (sh "clojure"
-      "-Sdeps"
-      (pr-str {:deps {'jonase/eastwood {:mvn/version "RELEASE"}}})
-      "-m"
-      "eastwood.lint"
+  (sh "clojure" "-M" "-m" "eastwood.lint"
       (pr-str (merge {:source-paths ["src"]
                       :linters linters
                       :namespaces namespaces}
@@ -138,11 +131,7 @@
 
 (defn- run-kibit [dir files relative-dir]
   (let [kibit-result
-        (sh "clojure"
-            "-Sdeps"
-            (pr-str {:deps {'tvaughan/kibit-runner
-                            {:mvn/version "RELEASE"}}})
-            "-m" "kibit-runner.cmdline" (cstr/join " " files)
+        (sh "clojure" "-M" "-m" "kibit-runner.cmdline" (cstr/join " " files)
             :dir dir)]
     (->> (cstr/split (:out kibit-result) #"\n\n")
          (map (fn [line]


### PR DESCRIPTION
The previous PR #15 was not sufficient since the script overrides the dependencies

https://github.com/xcoo/clj-lint-action/blob/f7a789aa0874ae073fbf10740362d5c9925efd99/lib/src/lint_action.clj#L84-L88

This PR removes the inline dependencies and makes it respect `deps.edn`.
Also, although the `docker build` succeeds locally and the reason why the [previous GitHub Actions run failed](https://github.com/xcoo/clj-lint-action/actions/runs/25470154242) is unclear, I confirmed that [updating GraalVM to version 22.3.3 makes GitHub Actions succeed](https://github.com/xcoo/clj-lint-action/actions/runs/25483139365), so I have included the version update.